### PR TITLE
Docker install PHP PCNTL extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,7 @@ RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-di
 RUN docker-php-ext-install \
   curl \
   intl \
+  pcntl \
   mcrypt \
   gd \
   ldap \


### PR DESCRIPTION
I suggest to install PHP [PCNTL](http://php.net/manual/ru/book.pcntl.php) extension, which you configure at line [34](https://github.com/spam312sn/php-symfony-oro/blob/3a30dafc42e18a70cfb1ae1382de9a793feba4be/Dockerfile#L34)